### PR TITLE
Map View with Treasure Visualization

### DIFF
--- a/animated-octo-happiness-ios/Info.plist
+++ b/animated-octo-happiness-ios/Info.plist
@@ -16,5 +16,9 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app needs access to your location to show your position on the map and place treasures nearby.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app needs access to your location to track treasures and notify you when you're near them.</string>
 </dict>
 </plist>

--- a/animated-octo-happiness-ios/animated-octo-happiness-ios/ContentView.swift
+++ b/animated-octo-happiness-ios/animated-octo-happiness-ios/ContentView.swift
@@ -9,13 +9,8 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        MapView()
+            .ignoresSafeArea()
     }
 }
 

--- a/animated-octo-happiness-ios/animated-octo-happiness-ios/LocationManager.swift
+++ b/animated-octo-happiness-ios/animated-octo-happiness-ios/LocationManager.swift
@@ -1,0 +1,63 @@
+//
+//  LocationManager.swift
+//  animated-octo-happiness-ios
+//
+//  Created by Auto Agent on 8/17/25.
+//
+
+import Foundation
+import CoreLocation
+import Combine
+
+class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+    private let locationManager = CLLocationManager()
+    
+    @Published var location: CLLocationCoordinate2D?
+    @Published var authorizationStatus: CLAuthorizationStatus = .notDetermined
+    @Published var isLocationAvailable = false
+    
+    override init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.distanceFilter = 10
+    }
+    
+    func requestLocationPermission() {
+        locationManager.requestWhenInUseAuthorization()
+    }
+    
+    func startUpdatingLocation() {
+        locationManager.startUpdatingLocation()
+    }
+    
+    func stopUpdatingLocation() {
+        locationManager.stopUpdatingLocation()
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let newLocation = locations.last else { return }
+        location = newLocation.coordinate
+        isLocationAvailable = true
+    }
+    
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        authorizationStatus = manager.authorizationStatus
+        
+        switch authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            startUpdatingLocation()
+        case .denied, .restricted:
+            isLocationAvailable = false
+        case .notDetermined:
+            requestLocationPermission()
+        @unknown default:
+            break
+        }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("Location error: \(error.localizedDescription)")
+        isLocationAvailable = false
+    }
+}

--- a/animated-octo-happiness-ios/animated-octo-happiness-ios/MapView.swift
+++ b/animated-octo-happiness-ios/animated-octo-happiness-ios/MapView.swift
@@ -1,0 +1,264 @@
+//
+//  MapView.swift
+//  animated-octo-happiness-ios
+//
+//  Created by Auto Agent on 8/17/25.
+//
+
+import SwiftUI
+import MapKit
+
+struct MapView: View {
+    @StateObject private var locationManager = LocationManager()
+    @StateObject private var treasureStore = TreasureStore()
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+        span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+    )
+    @State private var showingAddTreasureAlert = false
+    @State private var tappedCoordinate: CLLocationCoordinate2D?
+    @State private var newTreasureName = ""
+    @State private var newTreasureDescription = ""
+    @State private var selectedTreasure: Treasure?
+    @State private var showingTreasureDetails = false
+    @State private var lastKnownLocation: CLLocationCoordinate2D?
+    
+    var body: some View {
+        ZStack {
+            MapViewRepresentable(
+                region: $region,
+                treasures: treasureStore.treasures,
+                onTapLocation: { coordinate in
+                    tappedCoordinate = coordinate
+                    showingAddTreasureAlert = true
+                },
+                onTapTreasure: { treasure in
+                    selectedTreasure = treasure
+                    showingTreasureDetails = true
+                }
+            )
+            .onAppear {
+                locationManager.requestLocationPermission()
+                if let userLocation = locationManager.location {
+                    region.center = userLocation
+                    lastKnownLocation = userLocation
+                }
+            }
+            .onReceive(locationManager.$location) { newLocation in
+                if let location = newLocation,
+                   lastKnownLocation == nil ||
+                   abs(location.latitude - (lastKnownLocation?.latitude ?? 0)) > 0.0001 ||
+                   abs(location.longitude - (lastKnownLocation?.longitude ?? 0)) > 0.0001 {
+                    withAnimation {
+                        region.center = location
+                        lastKnownLocation = location
+                    }
+                }
+            }
+            
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    
+                    Button(action: centerOnUserLocation) {
+                        Image(systemName: "location.fill")
+                            .padding()
+                            .background(Color.white)
+                            .clipShape(Circle())
+                            .shadow(radius: 3)
+                    }
+                    .padding()
+                }
+            }
+        }
+        .alert("Add Treasure", isPresented: $showingAddTreasureAlert) {
+            TextField("Treasure Name", text: $newTreasureName)
+            TextField("Description", text: $newTreasureDescription)
+            Button("Cancel", role: .cancel) {
+                resetAddTreasureForm()
+            }
+            Button("Add") {
+                if let coordinate = tappedCoordinate, !newTreasureName.isEmpty {
+                    treasureStore.createTreasure(
+                        at: coordinate,
+                        name: newTreasureName,
+                        description: newTreasureDescription
+                    )
+                    resetAddTreasureForm()
+                }
+            }
+        } message: {
+            Text("Enter details for the new treasure")
+        }
+        .sheet(isPresented: $showingTreasureDetails) {
+            if let treasure = selectedTreasure {
+                TreasureDetailView(treasure: treasure, treasureStore: treasureStore)
+            }
+        }
+    }
+    
+    private func centerOnUserLocation() {
+        if let location = locationManager.location {
+            withAnimation {
+                region.center = location
+            }
+        }
+    }
+    
+    private func resetAddTreasureForm() {
+        newTreasureName = ""
+        newTreasureDescription = ""
+        tappedCoordinate = nil
+    }
+}
+
+struct MapViewRepresentable: UIViewRepresentable {
+    @Binding var region: MKCoordinateRegion
+    let treasures: [Treasure]
+    let onTapLocation: (CLLocationCoordinate2D) -> Void
+    let onTapTreasure: (Treasure) -> Void
+    
+    func makeUIView(context: Context) -> MKMapView {
+        let mapView = MKMapView()
+        mapView.delegate = context.coordinator
+        mapView.showsUserLocation = true
+        mapView.setRegion(region, animated: false)
+        
+        let tapGesture = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        mapView.addGestureRecognizer(tapGesture)
+        
+        return mapView
+    }
+    
+    func updateUIView(_ mapView: MKMapView, context: Context) {
+        mapView.setRegion(region, animated: true)
+        
+        let currentAnnotations = mapView.annotations.compactMap { $0 as? TreasureAnnotation }
+        let currentTreasureIds = Set(currentAnnotations.map { $0.treasure.id })
+        let newTreasureIds = Set(treasures.map { $0.id })
+        
+        let toRemove = currentAnnotations.filter { !newTreasureIds.contains($0.treasure.id) }
+        mapView.removeAnnotations(toRemove)
+        
+        let toAdd = treasures.filter { !currentTreasureIds.contains($0.id) }
+        let newAnnotations = toAdd.map { TreasureAnnotation(treasure: $0) }
+        mapView.addAnnotations(newAnnotations)
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, MKMapViewDelegate {
+        var parent: MapViewRepresentable
+        
+        init(_ parent: MapViewRepresentable) {
+            self.parent = parent
+        }
+        
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let mapView = gesture.view as? MKMapView else { return }
+            
+            let tapPoint = gesture.location(in: mapView)
+            let coordinate = mapView.convert(tapPoint, toCoordinateFrom: mapView)
+            
+            parent.onTapLocation(coordinate)
+        }
+        
+        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            guard let treasureAnnotation = annotation as? TreasureAnnotation else {
+                return nil
+            }
+            
+            let identifier = "TreasurePin"
+            var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) as? MKMarkerAnnotationView
+            
+            if annotationView == nil {
+                annotationView = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+                annotationView?.canShowCallout = true
+                let button = UIButton(type: .detailDisclosure)
+                annotationView?.rightCalloutAccessoryView = button
+            } else {
+                annotationView?.annotation = annotation
+            }
+            
+            annotationView?.markerTintColor = treasureAnnotation.treasure.isCollected ? .yellow : .red
+            annotationView?.glyphImage = UIImage(systemName: treasureAnnotation.treasure.isCollected ? "star.fill" : "mappin.circle.fill")
+            
+            return annotationView
+        }
+        
+        func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
+            guard let treasureAnnotation = view.annotation as? TreasureAnnotation else { return }
+            parent.onTapTreasure(treasureAnnotation.treasure)
+        }
+        
+        func mapViewDidChangeVisibleRegion(_ mapView: MKMapView) {
+            parent.region = mapView.region
+        }
+    }
+}
+
+struct TreasureDetailView: View {
+    let treasure: Treasure
+    @ObservedObject var treasureStore: TreasureStore
+    @Environment(\.dismiss) var dismiss
+    
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 20) {
+                Text(treasure.name)
+                    .font(.largeTitle)
+                    .bold()
+                
+                Text(treasure.treasureDescription)
+                    .font(.body)
+                
+                HStack {
+                    Image(systemName: "mappin.circle")
+                    Text("\(treasure.latitude, specifier: "%.4f"), \(treasure.longitude, specifier: "%.4f")")
+                        .font(.caption)
+                }
+                
+                HStack {
+                    Image(systemName: "calendar")
+                    Text(treasure.createdAt, style: .date)
+                        .font(.caption)
+                }
+                
+                if treasure.isCollected {
+                    Label("Collected", systemImage: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                } else {
+                    Button(action: {
+                        treasureStore.collectTreasure(treasure)
+                        dismiss()
+                    }) {
+                        Label("Mark as Collected", systemImage: "star.fill")
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.blue)
+                            .foregroundColor(.white)
+                            .cornerRadius(10)
+                    }
+                }
+                
+                Spacer()
+            }
+            .padding()
+            .navigationBarTitle("Treasure Details", displayMode: .inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    MapView()
+}

--- a/animated-octo-happiness-ios/animated-octo-happiness-ios/Treasure.swift
+++ b/animated-octo-happiness-ios/animated-octo-happiness-ios/Treasure.swift
@@ -1,0 +1,61 @@
+//
+//  Treasure.swift
+//  animated-octo-happiness-ios
+//
+//  Created by Auto Agent on 8/17/25.
+//
+
+import Foundation
+import CoreLocation
+import MapKit
+
+struct Treasure: Identifiable, Codable {
+    let id: UUID
+    let name: String
+    let treasureDescription: String
+    let latitude: Double
+    let longitude: Double
+    let createdAt: Date
+    var isCollected: Bool
+    
+    init(id: UUID = UUID(), 
+         name: String, 
+         description: String, 
+         latitude: Double, 
+         longitude: Double, 
+         createdAt: Date = Date(), 
+         isCollected: Bool = false) {
+        self.id = id
+        self.name = name
+        self.treasureDescription = description
+        self.latitude = latitude
+        self.longitude = longitude
+        self.createdAt = createdAt
+        self.isCollected = isCollected
+    }
+    
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}
+
+class TreasureAnnotation: NSObject, MKAnnotation {
+    let treasure: Treasure
+    
+    init(treasure: Treasure) {
+        self.treasure = treasure
+        super.init()
+    }
+    
+    var coordinate: CLLocationCoordinate2D {
+        treasure.coordinate
+    }
+    
+    var title: String? {
+        treasure.name
+    }
+    
+    var subtitle: String? {
+        treasure.treasureDescription
+    }
+}

--- a/animated-octo-happiness-ios/animated-octo-happiness-ios/TreasureStore.swift
+++ b/animated-octo-happiness-ios/animated-octo-happiness-ios/TreasureStore.swift
@@ -1,0 +1,95 @@
+//
+//  TreasureStore.swift
+//  animated-octo-happiness-ios
+//
+//  Created by Auto Agent on 8/17/25.
+//
+
+import Foundation
+import Combine
+import CoreLocation
+
+class TreasureStore: ObservableObject {
+    @Published var treasures: [Treasure] = []
+    
+    private let userDefaults = UserDefaults.standard
+    private let treasuresKey = "SavedTreasures"
+    
+    init() {
+        loadTreasures()
+    }
+    
+    func addTreasure(_ treasure: Treasure) {
+        treasures.append(treasure)
+        saveTreasures()
+    }
+    
+    func removeTreasure(_ treasure: Treasure) {
+        treasures.removeAll { $0.id == treasure.id }
+        saveTreasures()
+    }
+    
+    func updateTreasure(_ treasure: Treasure) {
+        if let index = treasures.firstIndex(where: { $0.id == treasure.id }) {
+            treasures[index] = treasure
+            saveTreasures()
+        }
+    }
+    
+    func collectTreasure(_ treasure: Treasure) {
+        if let index = treasures.firstIndex(where: { $0.id == treasure.id }) {
+            treasures[index].isCollected = true
+            saveTreasures()
+        }
+    }
+    
+    func createTreasure(at coordinate: CLLocationCoordinate2D, name: String, description: String) {
+        let treasure = Treasure(
+            name: name,
+            description: description,
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude
+        )
+        addTreasure(treasure)
+    }
+    
+    private func saveTreasures() {
+        if let encoded = try? JSONEncoder().encode(treasures) {
+            userDefaults.set(encoded, forKey: treasuresKey)
+        }
+    }
+    
+    private func loadTreasures() {
+        if let data = userDefaults.data(forKey: treasuresKey),
+           let decoded = try? JSONDecoder().decode([Treasure].self, from: data) {
+            treasures = decoded
+        } else {
+            addSampleTreasures()
+        }
+    }
+    
+    private func addSampleTreasures() {
+        let sampleTreasures = [
+            Treasure(
+                name: "Golden Gate Bridge View",
+                description: "A beautiful view of the iconic bridge",
+                latitude: 37.8199,
+                longitude: -122.4783
+            ),
+            Treasure(
+                name: "Fisherman's Wharf",
+                description: "Sea lions and street performers await",
+                latitude: 37.8080,
+                longitude: -122.4177
+            ),
+            Treasure(
+                name: "Coit Tower",
+                description: "Panoramic views of the city",
+                latitude: 37.8024,
+                longitude: -122.4058
+            )
+        ]
+        treasures = sampleTreasures
+        saveTreasures()
+    }
+}


### PR DESCRIPTION
## Overview
Implementing MapKit integration to display current location and show treasures as map pins.

## Changes
- ✅ Add MapKit framework integration with UIViewRepresentable
- ✅ Display user's current location on map
- ✅ Show saved treasures as map annotations
- ✅ Implement treasure placement UI with tap gesture
- ✅ Add map controls (zoom, pan, center on user)
- ✅ Create persistent treasure storage with UserDefaults
- ✅ Add treasure collection functionality

## Related Issues
Fixes #4

## Dependencies
- Core Location foundation (implemented in LocationManager)
- Treasure data model (implemented)

## Testing
- [x] Map view displays correctly
- [x] User location shown with blue dot
- [x] Treasures appear as custom pins (red = uncollected, yellow = collected)
- [x] Can tap to place new treasures
- [x] Treasure pins show info when tapped
- [x] Map centers on user location at launch
- [x] Build succeeds without errors

## Implementation Details
- Used UIViewRepresentable to wrap MKMapView for full control
- Implemented tap gesture recognizer for placing treasures
- Created custom annotation views with collection status
- Added sample treasures for San Francisco area
- Treasure data persists across app launches

## Next Steps
- Consider adding treasure search/filter functionality
- Add distance-based treasure discovery
- Implement AR view for treasure visualization